### PR TITLE
Fix for empty strings

### DIFF
--- a/lib/write_xlsx/package/shared_strings.rb
+++ b/lib/write_xlsx/package/shared_strings.rb
@@ -82,7 +82,7 @@ module Writexlsx
       # Write the sst string elements.
       #
       def write_sst_strings
-        @strings.each { |string| write_si(string) }
+        @strings.each { |string| write_si(string.empty? ? " " : string) }
       end
 
       #


### PR DESCRIPTION
If you have a workbook with empty strings in a cell then SharedStrings.write_si chokes.  I added a simple fix in write_sst_strings such that if the string is empty then pass a single space to write_si.
