### PR TITLE
Make temp dir usage multi-process safe

### DIFF
--- a/lib/write_xlsx/workbook.rb
+++ b/lib/write_xlsx/workbook.rb
@@ -93,7 +93,7 @@ module Writexlsx
       @writer = Package::XMLWriterSimple.new
 
       @tempdir = options[:tempdir] ||
-        File.join(Dir.tmpdir, Digest::MD5.hexdigest(Time.now.to_s))
+        File.join(Dir.tmpdir, Digest::MD5.hexdigest("#{Time.now.to_f.to_s}-#{Process.pid}"))
       setup_filename(file)
       @date_1904           = options[:date_1904] || false
       @activesheet         = 0


### PR DESCRIPTION
Safeguards against temp dir collisions in multi-process environments by injecting the PID into the dir name. This makes it safer for use in Sidekiq, Resque, etc. 

In containerised (Docker, et al) environments, however, and due to the extreme predictability of PIDs, this will not be entirely safe. I shied away from injecting a SecureRandom dependency for UUID generation, but this would probably be a better solution.