### PR TITLE
Replaced eval call to #send in Format#set_format_properties.

### DIFF
--- a/lib/write_xlsx/format.rb
+++ b/lib/write_xlsx/format.rb
@@ -287,11 +287,10 @@ module Writexlsx
 
           # Create a sub to set the property.
           if value.respond_to?(:to_str) || !value.respond_to?(:+)
-            s = "set_#{key}('#{value}')"
+            send("set_#{key}", value.to_s)
           else
-            s = "set_#{key}(#{value})"
+            send("set_#{key}", value)
           end
-          eval s
         end
       end
     end


### PR DESCRIPTION
Ruby can use `send` instean of `eval`. It is more secure and faster. 
Also memory leak is gone at this line.