### PR TITLE
Remove deprecation warnings for deprecated Object#=~ is called on Int…

### DIFF
--- a/lib/write_xlsx/package/xml_writer_simple.rb
+++ b/lib/write_xlsx/package/xml_writer_simple.rb
@@ -118,7 +118,7 @@ module Writexlsx
       end
 
       def escape_attributes(str = '')
-        return str if !(str =~ /["&<>]/)
+        return str if !(str.to_s =~ /["&<>]/)
 
         str.
           gsub(/&/, "&amp;").
@@ -128,7 +128,7 @@ module Writexlsx
       end
 
       def escape_data(str = '')
-        if str =~ /[&<>]/
+        if str.to_s =~ /[&<>]/
           str.gsub(/&/, '&amp;').
             gsub(/</, '&lt;').
             gsub(/>/, '&gt;')

--- a/lib/write_xlsx/utility.rb
+++ b/lib/write_xlsx/utility.rb
@@ -243,7 +243,7 @@ module Writexlsx
 
     # Check for a cell reference in A1 notation and substitute row and column
     def row_col_notation(args)   # :nodoc:
-      if args[0] =~ /^\D/
+      if args[0].to_s =~ /^\D/
         substitute_cellref(*args)
       else
         args

--- a/lib/write_xlsx/worksheet.rb
+++ b/lib/write_xlsx/worksheet.rb
@@ -720,7 +720,7 @@ module Writexlsx
     #
     def set_column(*args)
       # Check for a cell reference in A1 notation and substitute row and column
-      if args[0] =~ /^\D/
+      if args[0].to_s =~ /^\D/
         row1, firstcol, row2, lastcol, *data = substitute_cellref(*args)
       else
         firstcol, lastcol, *data = args


### PR DESCRIPTION
Remove deprecation warnings for deprecated Object#=~ is called on Integer; it always returns nil