### PR TITLE
Small optimization in Worksheet#write_cell_column_dimension.

### DIFF
--- a/lib/write_xlsx/worksheet.rb
+++ b/lib/write_xlsx/worksheet.rb
@@ -6789,8 +6789,11 @@ module Writexlsx
     end
 
     def write_cell_column_dimension(row_num)  # :nodoc:
+      row_data = @cell_data_table[row_num]
       (@dim_colmin .. @dim_colmax).each do |col_num|
-        @cell_data_table[row_num][col_num].write_cell if @cell_data_table[row_num][col_num]
+        if (value = row_data[col_num])
+          value.write_cell
+        end
       end
     end
 


### PR DESCRIPTION
I didn't run benchmarks, but it should work faster, because access to array item moved out of cycle.