### PR TITLE
Add Feature to update formatting of cells not changing contents of cells

### DIFF
--- a/lib/write_xlsx/worksheet.rb
+++ b/lib/write_xlsx/worksheet.rb
@@ -2554,7 +2554,7 @@ module Writexlsx
       store_row_col_max_min_values(row, col)
 
       # keep original value of cell
-      if @cell_data_table.dig(row, col).nil? 
+      if @cell_data_table[row].nil? || @cell_data_table[row][col].nil?
         format = @workbook.add_format(params)
         write_blank(row, col, format)
       elsif @cell_data_table[row][col].xf.nil?

--- a/lib/write_xlsx/worksheet.rb
+++ b/lib/write_xlsx/worksheet.rb
@@ -2528,6 +2528,23 @@ module Writexlsx
       end
     end
 
+    #
+    # :call-seq:
+    #   update_format_with_params(row, col, format_params)
+    #
+    # Update formatting of the cell to the specified row and column (zero indexed).
+    #
+    #     worksheet.update_format_with_params(0, 0, color: 'red')
+    #
+    # This method is used to update formatting of the cell keeping cell contents 
+    # and formatting.
+    #
+    # If the cell doesn't have CellData object, this method create a CellData 
+    # using write_blank method.
+    # If the cell has CellData but no Format object, this method fetch contents
+    # of cell from the CellData object and recreate CellData using write method.
+    # otherwise this method just update parameters of existing Format object.
+    #
     def update_format_with_params(*args)
       row, col, params = row_col_notation(args)
       raise WriteXLSXInsufficientArgumentError if row.nil? || col.nil? || params.nil?
@@ -2559,6 +2576,18 @@ module Writexlsx
       end
     end
 
+    #
+    # :call-seq:
+    #   update_range_format_with_params(row_first, col_first, row_last, col_last, format_params)
+    #
+    # Update formatting of cells in range to the specified row and column (zero indexed).
+    #
+    #     worksheet.update_range_format_with_params(0, 0, 3, 3, color: 'red')
+    #
+    # This method is used to update formatting of multiple cells keeping cells' contents 
+    # and formatting.
+    #
+    #
     def update_range_format_with_params(*args)
       row_first, col_first, row_last, col_last, params = row_col_notation(args)
 

--- a/lib/write_xlsx/worksheet.rb
+++ b/lib/write_xlsx/worksheet.rb
@@ -2565,6 +2565,7 @@ module Writexlsx
           format = @workbook.add_format
           cell_data = @cell_data_table[row][col]
           format.copy(cell_data.xf)
+          format.set_format_properties(params)
         end
         # keep original value of cell
         if cell_data.is_a? FormulaCellData

--- a/test/worksheet/test_update_format_methods.rb
+++ b/test/worksheet/test_update_format_methods.rb
@@ -72,6 +72,14 @@ class TestUpdateFormatMethods < Test::Unit::TestCase
     assert_equal(written_string, string)
   end
 
+  def test_update_format_with_params_should_not_update_other_cells_format
+    format = @workbook.add_format(bold: 1)
+    @worksheet.write_row(0, 0, ['', '', '', '', ''], format)
+    @worksheet.update_format_with_params(0, 0, bold: 0)
+    assert_not_equal(@worksheet.instance_variable_get(:@cell_data_table)[0][0].xf, 
+                     @worksheet.instance_variable_get(:@cell_data_table)[0][1].xf )
+  end
+
   def test_update_range_format_with_params_with_insufficient_args_raise_InsufficientArgumentError
     assert_raise(WriteXLSXInsufficientArgumentError) do
       @worksheet.update_range_format_with_params

--- a/test/worksheet/test_update_format_methods.rb
+++ b/test/worksheet/test_update_format_methods.rb
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+require 'helper'
+require 'write_xlsx'
+require 'stringio'
+
+class TestWriteMethods < Test::Unit::TestCase
+  def setup
+    @workbook = WriteXLSX.new(StringIO.new)
+    @worksheet = @workbook.add_worksheet('')
+  end
+
+  def test_update_format_with_params_with_insufficient_args_raise_InsufficientArgumentError
+    assert_raise(WriteXLSXInsufficientArgumentError) do
+      @worksheet.update_format_with_params
+    end
+    assert_raise(WriteXLSXInsufficientArgumentError) do
+      @worksheet.update_format_with_params(0)
+    end
+    assert_raise(WriteXLSXInsufficientArgumentError) do
+      @worksheet.update_format_with_params('A1')
+    end
+  end
+
+  def test_update_format_with_params_with_valid_arg_not_raise
+    assert_nothing_raised do
+      @worksheet.update_format_with_params(0, 0, color: 'red', border: 2)
+    end
+    assert_nothing_raised do
+      @worksheet.update_format_with_params('B2', align: 'center')
+    end
+  end
+
+  def test_update_format_with_params_should_write_blank_when_there_is_no_CellData
+    assert_nil(@worksheet.instance_variable_get(:@cell_data_table)[0])
+    @worksheet.update_format_with_params(0, 0, left: 4)
+    assert @worksheet.instance_variable_get(:@cell_data_table)[0][0] != nil
+  end
+
+  def test_update_format_with_params_should_keep_data_when_updating_format
+    number = 153
+    @worksheet.write(0, 0, number)
+    @worksheet.update_format_with_params(0, 0, bg_color: 'gray')
+    assert_equal(@worksheet.instance_variable_get(:@cell_data_table)[0][0].data, number)
+
+    string = 'Hello, World!'
+    @worksheet.write(0, 0, string)
+    @worksheet.update_format_with_params(0, 0, bg_color: 'gray')
+    written_string = @workbook.shared_strings.string(@worksheet.instance_variable_get(:@cell_data_table)[0][0].data[:sst_id])
+    assert_equal(written_string, string)
+
+    formula = '=1+1'
+    @worksheet.write(0, 0, formula)
+    @worksheet.update_format_with_params(0, 0, bg_color: 'gray')
+    assert_equal(@worksheet.instance_variable_get(:@cell_data_table)[0][0].token, '1+1')
+
+    array_formula = '{=SUM(B1:C1*B2:C2)}'
+    @worksheet.write('A1', array_formula)
+    @worksheet.update_format_with_params(0, 0, bg_color: 'gray')
+    assert_equal(@worksheet.instance_variable_get(:@cell_data_table)[0][0].token, 'SUM(B1:C1*B2:C2)')
+
+    url = 'https://www.writexlsx.io'
+    @worksheet.write(0, 0, url)
+    @worksheet.update_format_with_params(0, 0, bg_color: 'gray')
+    written_string = @workbook.shared_strings.string(@worksheet.instance_variable_get(:@cell_data_table)[0][0].data[:sst_id])
+    assert_equal(written_string, url)
+
+    string = 'Hello, World!'
+    format = @workbook.add_format(color: 'white')
+    @worksheet.write(0, 0, string, format)
+    @worksheet.update_format_with_params(0, 0, bg_color: 'gray')
+    written_string = @workbook.shared_strings.string(@worksheet.instance_variable_get(:@cell_data_table)[0][0].data[:sst_id])
+    assert_equal(written_string, string)
+  end
+
+  def test_update_range_format_with_params_with_insufficient_args_raise_InsufficientArgumentError
+    assert_raise(WriteXLSXInsufficientArgumentError) do
+      @worksheet.update_range_format_with_params
+    end
+    assert_raise(WriteXLSXInsufficientArgumentError) do
+      @worksheet.update_range_format_with_params(0, 0)
+    end
+    assert_raise(WriteXLSXInsufficientArgumentError) do
+      @worksheet.update_range_format_with_params('A1')
+    end
+    assert_raise(WriteXLSXInsufficientArgumentError) do
+      @worksheet.update_range_format_with_params(0, 0, 3, 3)
+    end
+    assert_raise(WriteXLSXInsufficientArgumentError) do
+      @worksheet.update_range_format_with_params('A2:C2')
+    end
+  end
+
+  def test_update_range_format_with_params_with_valid_arg_not_raise
+    assert_nothing_raised do
+      @worksheet.update_range_format_with_params(0, 0, 3, 3, bold: 1)
+    end
+    assert_nothing_raised do
+      @worksheet.update_range_format_with_params('A2:D5', bold: 1)
+    end
+  end
+end

--- a/test/worksheet/test_update_format_methods.rb
+++ b/test/worksheet/test_update_format_methods.rb
@@ -78,6 +78,8 @@ class TestUpdateFormatMethods < Test::Unit::TestCase
     @worksheet.update_format_with_params(0, 0, bold: 0)
     assert_not_equal(@worksheet.instance_variable_get(:@cell_data_table)[0][0].xf, 
                      @worksheet.instance_variable_get(:@cell_data_table)[0][1].xf )
+    assert_equal(@worksheet.instance_variable_get(:@cell_data_table)[0][0].xf.bold, 0)
+    assert_equal(@worksheet.instance_variable_get(:@cell_data_table)[0][1].xf.bold, 1)
   end
 
   def test_update_range_format_with_params_with_insufficient_args_raise_InsufficientArgumentError

--- a/test/worksheet/test_update_format_methods.rb
+++ b/test/worksheet/test_update_format_methods.rb
@@ -3,7 +3,7 @@ require 'helper'
 require 'write_xlsx'
 require 'stringio'
 
-class TestWriteMethods < Test::Unit::TestCase
+class TestUpdateFormatMethods < Test::Unit::TestCase
   def setup
     @workbook = WriteXLSX.new(StringIO.new)
     @worksheet = @workbook.add_worksheet('')


### PR DESCRIPTION
Hi! I'm really happy to find this great gem.
But when I've used this gem, I'd felt that I'd wanted to update just some parameters of some cells keeping cells' contents and formatting already applied. 
Because, It was really hard to draw some tables like the following.
<img width="410" alt="Screen Shot 2020-10-16 at 9 46 46 AM" src="https://user-images.githubusercontent.com/25764173/96200321-925bd380-0f94-11eb-9d4b-6efadd330653.png">

I needed to create formats for every cells and codes became really verbose.
```
workbook = WriteXLSX.new('some.xlsx')
worksheet = workbook.add_worksheet

top_left__header_format = workbook.add_format(align: 'center', bold: 1, bg_color: 31, border: 1, top: 2, left: 2)
top_header_format = workbook.add_format(align: 'center', bold: 1, bg_color: 31, border: 1, top: 2)
top_right_header_format = workbook.add_format(align: 'center', bold: 1, bg_color: 31, border: 1, top: 2, right: 2)
top_left_body_format = workbook.add_format(align: 'center', border: 1, top: 2, left: 2)
top_body_format = workbook.add_format(align: 'center', border: 1, top: 2)
top_right_body_format = workbook.add_format(align: 'center', border: 1, top: 2, right: 2)
left_body_format = workbook.add_format(align: 'center', border: 1, left: 2)
body_format = workbook.add_format(align: 'center', border: 1)
right_body_format = workbook.add_format(align: 'center', border: 1, right: 2)
bottom_left_body_format = workbook.add_format(align: 'center', border: 1, bottom: 2, left: 2)
bottom_body_format = workbook.add_format(align: 'center', border: 1, bottom: 2)
bottom_right_body_format = workbook.add_format(align: 'center', border: 1, bottom: 2, right: 2)

worksheet.write(0, 0, 'Table', top_left_header_format)
worksheet.write(0, 1, 'Header', top_header_format)
worksheet.write(0, 2, 'Contents', top_right_header_format)
worksheet.write(1, 0, 'table', top_left_body_format)
worksheet.write(1, 1, 'body', top_body_format)
worksheet.write(1, 2, 'contents', top_right_body_format)
worksheet.write(2, 0, 'table', left_body_format)
worksheet.write(2, 1, 'body', body_format)
worksheet.write(2, 2, 'contents', right_body_format)
worksheet.write(3, 0, 'table', bottom_left_body_format)
worksheet.write(3, 1, 'body', bottom_body_format)
worksheet.write(3, 2, 'contents', bottom_right_body_format)
```
So, I thought It would be great if I can just update formatting of the specified cell and implemented the feature.
With methods I added above table could be drawn like this.
```
workbook = WriteXLSX.new('some.xlsx')
worksheet = workbook.add_worksheet

common_format = workbook.add_format(align: 'center', border: 1)

table_contents = [
  ['Table', 'Header', 'Contents'],
  ['table', 'body', contents'],
  ['table', 'body', contents'],
  ['table', 'body', contents']
]

worksheet.write_col(0, 0, table_contents, common_format)
worksheet.update_range_format_with_params(0, 0, 0, 2, bold: 1, top: 2, bottom: 2, bg_color: 31)
worksheet.update_range_format_with_params(0, 0, 3, 0, left: 2)
worksheet.update_range_format_with_params(0, 2, 3, 2, right: 2)
worksheet.update_range_format_with_params(3, 0, 3, 2, bottom: 2)
```
