### PR TITLE
worksheet#write should write a string, If cell format is force text

### DIFF
--- a/lib/write_xlsx/format.rb
+++ b/lib/write_xlsx/format.rb
@@ -827,6 +827,10 @@ module Writexlsx
       attributes
     end
 
+    def force_text_format?
+      @num_format == 49 # Text format ('@')
+    end
+
     private
 
     def write_font_shapes(writer)

--- a/lib/write_xlsx/worksheet.rb
+++ b/lib/write_xlsx/worksheet.rb
@@ -1798,8 +1798,11 @@ module Writexlsx
       row_col_args = row_col_notation(args)
       token = row_col_args[2] || ''
 
+      fmt = row_col_args[3]
+      if Format.is_a?(Writexlsx::Format) && fmt.force_text_format?
+        write_string(*args) # Force text format
       # Match an array ref.
-      if token.respond_to?(:to_ary)
+      elsif token.respond_to?(:to_ary)
         write_row(*args)
       elsif token.respond_to?(:coerce)  # Numeric
         write_number(*args)


### PR DESCRIPTION
if we set text format, worksheet#write should save a text, ever if we write number to it.
For example, phone numbers should be saved as strings.

It should resolve https://github.com/cxn03651/write_xlsx/issues/23
