### PR TITLE
Eliminate Jruby warning "interpreted as binary operator"

### DIFF
--- a/lib/write_xlsx/package/conditional_format.rb
+++ b/lib/write_xlsx/package/conditional_format.rb
@@ -696,7 +696,7 @@ module Writexlsx
 
           # Ensure we don't set user properties for lowest icon.
           max_data = user_props.size
-          max_data = total_icons -1 if max_data >= total_icons
+          max_data = total_icons - 1 if max_data >= total_icons
 
           (0..max_data - 1).each do |i|
             # Set the user defined 'value' property.


### PR DESCRIPTION
`total_icons -1` produces a warning in Jury that it will be interpreted as a binary operator even though it looks like a unary operator. Changing it to `total_icons - 1` eliminates the warning.

Please include this in your next release. Thank you.