### PR TITLE
Remove zip-zip dependency.

### DIFF
--- a/bin/extract_vba.rb
+++ b/bin/extract_vba.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # -*- encoding: utf-8 -*-
 
-require 'zip/zipfilesystem'
+require 'zip/filesystem'
 require 'fileutils'
 
   # src  zip filename
@@ -9,7 +9,7 @@ require 'fileutils'
   # options :fs_encoding=[UTF-8,Shift_JIS,EUC-JP]
   def extract_vba_project(src, dest, options = {})
     FileUtils.makedirs(dest)
-    Zip::ZipInputStream.open(src) do |is|
+    Zip::InputStream.open(src) do |is|
       loop do
         entry = is.get_next_entry()
         break if entry.nil?()

--- a/lib/write_xlsx/zip_file_utils.rb
+++ b/lib/write_xlsx/zip_file_utils.rb
@@ -3,7 +3,7 @@
 # from http://d.hatena.ne.jp/alunko/20071021
 #
 require 'kconv'
-require 'zip/zipfilesystem'
+require 'zip/filesystem'
 require 'fileutils'
 
 module ZipFileUtils
@@ -15,7 +15,7 @@ module ZipFileUtils
     src = File.expand_path(src)
     dest = File.expand_path(dest)
     File.unlink(dest) if File.exist?(dest)
-    Zip::ZipFile.open(dest, Zip::ZipFile::CREATE) {|zf|
+    Zip::File.open(dest, Zip::File::CREATE) {|zf|
       if(File.file?(src))
         zf.add(encode_path(File.basename(src), options[:fs_encoding]), src)
         break
@@ -37,7 +37,7 @@ module ZipFileUtils
   # options :fs_encoding=[UTF-8,Shift_JIS,EUC-JP]
   def self.unzip(src, dest, options = {})
     FileUtils.makedirs(dest)
-    Zip::ZipInputStream.open(src) do |is|
+    Zip::InputStream.open(src) do |is|
       loop do
         entry = is.get_next_entry()
         break unless entry

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -77,7 +77,7 @@ class Minitest::Test
 
   def entrys(xlsx)
     result = []
-    Zip::ZipFile.foreach(xlsx) { |entry| result << entry }
+    Zip::File.foreach(xlsx) { |entry| result << entry }
     result
   end
 

--- a/write_xlsx.gemspec
+++ b/write_xlsx.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   gem.add_runtime_dependency 'rubyzip', '>= 1.0.0'
-  gem.add_runtime_dependency 'zip-zip'
   gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'byebug'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Since `write_xlsx` already requires rubyzip 1+, switch to using its API consistently and drop the `zip-zip` workaround dependency to make this package lighter when included in projects.