### PR TITLE
Reduce RAM usage and speed up workbook#close

### DIFF
--- a/lib/write_xlsx/package/xml_writer_simple.rb
+++ b/lib/write_xlsx/package/xml_writer_simple.rb
@@ -13,6 +13,11 @@ module Writexlsx
 
       def initialize
         @io = StringIO.new
+        # Will allocate new string once, then use allocated string
+        # Key is tag name
+        # Only tags without attributes will be cached
+        @tag_start_cache = {}
+        @tag_end_cache = {}
       end
 
       def set_xml_writer(filename = nil)
@@ -41,7 +46,16 @@ module Writexlsx
       end
 
       def start_tag_str(tag, attr = [])
-        "<#{tag}#{key_vals(attr)}>"
+        if attr.empty?
+          result = @tag_start_cache[tag]
+          unless result
+            result = "<#{tag}>"
+            @tag_start_cache[tag] = result
+          end
+        else
+          result = "<#{tag}#{key_vals(attr)}>"
+        end
+        result
       end
 
       def end_tag(tag)
@@ -49,7 +63,12 @@ module Writexlsx
       end
 
       def end_tag_str(tag)
-        "</#{tag}>"
+        result = @tag_end_cache[tag]
+        unless result
+          result = "</#{tag}>"
+          @tag_end_cache[tag] = result
+        end
+        result
       end
 
       def empty_tag(tag, attr = [])


### PR DESCRIPTION
`Workbook#close` run faster on ~15% and RAM reduced on ~20-25% (excluded ~30% memory allocations).
I append cache for tags without attributes (separate for open and close).

My test scratch:

```Ruby
require "benchmark"
require "write_xlsx"
require 'memory_profiler'

do_mem_profile = false

def print_memory_usage(caption)
  puts "#{caption} Process RAM usage: %d Kb" % (`ps -o rss= -p #{Process.pid}`.to_i)
end

print_memory_usage "Starting"

temp_io = StringIO.new
workbook = WriteXLSX.new(temp_io)
worksheet = workbook.add_worksheet

Benchmark.bm  do |x|
  x.report "Fill Excel Table" do
    (1..2000).each do |row|
      (1..50).each do |col|
        value = "R#{row}-c#{col}"
        worksheet.write row, col, value
      end
    end
  end
end

print_memory_usage "Test workbook initialized"


MemoryProfiler.start if do_mem_profile

Benchmark.bm  do |x|
  x.report "Save Excel Table" do
    workbook.close
  end
end

print_memory_usage "After save"

worksheet = nil
workbook = nil

report = MemoryProfiler.stop if do_mem_profile
report.pretty_print(detailed_report: false) if do_mem_profile
report = nil if do_mem_profile

print_memory_usage "Finished"
```

Without Memory profile (do_mem_profile = false), Git version (latest `main` branch) output is:
```
Starting Process RAM usage: 29780 Kb
       user     system      total        real
Fill Excel Table  0.448251   0.002581   0.450832 (  0.452276)
Test workbook initialized Process RAM usage: 50116 Kb
       user     system      total        real
Save Excel Table  0.976262   0.008830   0.985092 (  0.987934)
After save Process RAM usage: 66668 Kb
Finished Process RAM usage: 66668 Kb
```

New version output is:
```
Starting Process RAM usage: 29660 Kb
       user     system      total        real
Fill Excel Table  0.438810   0.009371   0.448181 (  0.449543)
Test workbook initialized Process RAM usage: 49988 Kb
       user     system      total        real
Save Excel Table  0.840877   0.010937   0.851814 (  0.854065)
After save Process RAM usage: 66544 Kb
Finished Process RAM usage: 66544 Kb
```

With Memory profiler (do_mem_profile = true), Git version output is:
```
Starting Process RAM usage: 29688 Kb
       user     system      total        real
Fill Excel Table  0.423080   0.012576   0.435656 (  0.436906)
Test workbook initialized Process RAM usage: 49836 Kb
       user     system      total        real
Save Excel Table  2.630090   0.211629   2.841719 (  2.850924)
After save Process RAM usage: 634384 Kb
Total allocated: 120923044 bytes (2437192 objects)
Total retained:  5011 bytes (58 objects)
Finished Process RAM usage: 1687988 Kb
```

New version output is:
```
Starting Process RAM usage: 29656 Kb
       user     system      total        real
Fill Excel Table  0.422104   0.011028   0.433132 (  0.434493)
Test workbook initialized Process RAM usage: 49808 Kb
       user     system      total        real
Save Excel Table  2.081195   0.166887   2.248082 (  2.255551)
After save Process RAM usage: 450368 Kb
Total allocated: 92847515 bytes (1735210 objects)
Total retained:  5011 bytes (58 objects)
Finished Process RAM usage: 1245884 Kb
```