### PR TITLE
Remove col row var

### DIFF
--- a/lib/write_xlsx/worksheet.rb
+++ b/lib/write_xlsx/worksheet.rb
@@ -994,7 +994,7 @@ module Writexlsx
       check_dimensions(row, col)
       store_row_col_max_min_values(row, col)
 
-      store_data_to_table(NumberCellData.new(self, row, col, num, xf))
+      store_data_to_table(NumberCellData.new(num, xf), row, col)
     end
 
     #
@@ -1016,7 +1016,7 @@ module Writexlsx
 
       index = shared_string_index(str.length > STR_MAX ? str[0, STR_MAX] : str)
 
-      store_data_to_table(StringCellData.new(self, row, col, index, xf))
+      store_data_to_table(StringCellData.new(index, xf), row, col)
     end
 
     #
@@ -1044,7 +1044,7 @@ module Writexlsx
 
       index = shared_string_index(xml_str_of_rich_string(fragments))
 
-      store_data_to_table(StringCellData.new(self, row, col, index, xf))
+      store_data_to_table(StringCellData.new(index, xf), row, col)
     end
 
     #
@@ -1067,7 +1067,7 @@ module Writexlsx
       check_dimensions(row, col)
       store_row_col_max_min_values(row, col)
 
-      store_data_to_table(BlankCellData.new(self, row, col, xf))
+      store_data_to_table(BlankCellData.new(xf), row, col)
     end
 
     #
@@ -1088,7 +1088,7 @@ module Writexlsx
         store_row_col_max_min_values(row, col)
         formula = formula.sub(/^=/, '')
 
-        store_data_to_table(FormulaCellData.new(self, row, col, formula, format, value))
+        store_data_to_table(FormulaCellData.new(formula, format, value), row, col)
       end
     end
 
@@ -1123,12 +1123,13 @@ module Writexlsx
 
       store_data_to_table(
         if type == 'a'
-          FormulaArrayCellData.new(self, row1, col1, formula, xf, range, value)
+          FormulaArrayCellData.new(formula, xf, range, value)
         elsif type == 'd'
-          DynamicFormulaArrayCellData.new(self, row1, col1, formula, xf, range, value)
+          DynamicFormulaArrayCellData.new(formula, xf, range, value)
         else
           raise "invalid type in write_array_formula_base()."
-        end
+        end,
+        row1, col1
       )
 
       # Pad out the rest of the area with formatted zeroes.
@@ -1176,7 +1177,7 @@ module Writexlsx
       check_dimensions(row, col)
       store_row_col_max_min_values(row, col)
 
-      store_data_to_table(BooleanCellData.new(self, row, col, val, xf))
+      store_data_to_table(BooleanCellData.new(val, xf), row, col)
     end
 
     #
@@ -1321,7 +1322,7 @@ module Writexlsx
       date_time = convert_date_time(str)
 
       if date_time
-        store_data_to_table(NumberCellData.new(self, row, col, date_time, xf))
+        store_data_to_table(NumberCellData.new(date_time, xf), row, col)
       else
         # If the date isn't valid then write it as a string.
         write_string(*args)
@@ -3119,7 +3120,7 @@ EOS
 
     def write_cell_column_dimension(row_num)  # :nodoc:
       (@dim_colmin..@dim_colmax).each do |col_num|
-        @cell_data_table[row_num][col_num].write_cell if @cell_data_table[row_num][col_num]
+        @cell_data_table[row_num][col_num].write_cell(self, row_num, col_num) if @cell_data_table[row_num][col_num]
       end
     end
 
@@ -3984,9 +3985,7 @@ EOS
       end
     end
 
-    def store_data_to_table(cell_data) # :nodoc:
-      row = cell_data.row
-      col = cell_data.col
+    def store_data_to_table(cell_data, row, col) # :nodoc:
       if @cell_data_table[row]
         @cell_data_table[row][col] = cell_data
       else

--- a/lib/write_xlsx/worksheet/cell_data.rb
+++ b/lib/write_xlsx/worksheet/cell_data.rb
@@ -6,14 +6,13 @@ module Writexlsx
     class CellData   # :nodoc:
       include Writexlsx::Utility
 
-      attr_reader :row, :col, :token, :xf
-      attr_reader :result, :range, :link_type, :url, :tip
+      attr_reader :xf
 
       #
       # attributes for the <cell> element. This is the innermost loop so efficiency is
       # important where possible.
       #
-      def cell_attributes # :nodoc:
+      def cell_attributes(worksheet, row, col) # :nodoc:
         xf_index = xf ? xf.get_xf_index : 0
         attributes = [
           ['r', xl_rowcol_to_cell(row, col)]
@@ -22,11 +21,11 @@ module Writexlsx
         # Add the cell format index.
         if xf_index != 0
           attributes << ['s', xf_index]
-        elsif @worksheet.set_rows[row] && @worksheet.set_rows[row][1]
-          row_xf = @worksheet.set_rows[row][1]
+        elsif worksheet.set_rows[row] && worksheet.set_rows[row][1]
+          row_xf = worksheet.set_rows[row][1]
           attributes << ['s', row_xf.get_xf_index]
-        elsif @worksheet.col_formats[col]
-          col_xf = @worksheet.col_formats[col]
+        elsif worksheet.col_formats[col]
+          col_xf = worksheet.col_formats[col]
           attributes << ['s', col_xf.get_xf_index]
         end
         attributes
@@ -38,10 +37,9 @@ module Writexlsx
     end
 
     class NumberCellData < CellData # :nodoc:
-      def initialize(worksheet, row, col, num, xf)
-        @worksheet = worksheet
-        @row = row
-        @col = col
+      attr_reader :token
+
+      def initialize(num, xf)
         @token = num
         @xf = xf
       end
@@ -50,18 +48,16 @@ module Writexlsx
         @token
       end
 
-      def write_cell
-        @worksheet.writer.tag_elements('c', cell_attributes) do
-          @worksheet.write_cell_value(token)
+      def write_cell(worksheet, row, col)
+        worksheet.writer.tag_elements('c', cell_attributes(worksheet, row, col)) do
+          worksheet.write_cell_value(token)
         end
       end
     end
 
     class StringCellData < CellData # :nodoc:
-      def initialize(worksheet, row, col, index, xf)
-        @worksheet = worksheet
-        @row = row
-        @col = col
+      attr_reader :token
+      def initialize(index, xf)
         @token = index
         @xf = xf
       end
@@ -71,11 +67,11 @@ module Writexlsx
       end
 
       TYPE_STR_ATTRS = %w[t s].freeze
-      def write_cell
-        attributes = cell_attributes
+      def write_cell(worksheet, row, col)
+        attributes = cell_attributes(worksheet, row, col)
         attributes << TYPE_STR_ATTRS
-        @worksheet.writer.tag_elements('c', attributes) do
-          @worksheet.write_cell_value(token)
+        worksheet.writer.tag_elements('c', attributes) do
+          worksheet.write_cell_value(token)
         end
       end
 
@@ -85,10 +81,9 @@ module Writexlsx
     end
 
     class FormulaCellData < CellData # :nodoc:
-      def initialize(worksheet, row, col, formula, xf, result)
-        @worksheet = worksheet
-        @row = row
-        @col = col
+      attr_reader :token, :result, :range, :link_type, :url
+
+      def initialize(formula, xf, result)
         @token = formula
         @xf = xf
         @result = result
@@ -98,11 +93,11 @@ module Writexlsx
         @result || 0
       end
 
-      def write_cell
+      def write_cell(worksheet, row, col)
         truefalse = { 'TRUE' => 1, 'FALSE' => 0 }
         error_code = ['#DIV/0!', '#N/A', '#NAME?', '#NULL!', '#NUM!', '#REF!', '#VALUE!']
 
-        attributes = cell_attributes
+        attributes = cell_attributes(worksheet, row, col)
         if @result && !(@result.to_s =~ /^([+-]?)(?=\d|\.\d)\d*(\.\d*)?([Ee]([+-]?\d+))?$/)
           if truefalse[@result]
             attributes << %w[t b]
@@ -113,18 +108,16 @@ module Writexlsx
             attributes << %w[t str]
           end
         end
-        @worksheet.writer.tag_elements('c', attributes) do
-          @worksheet.write_cell_formula(token)
-          @worksheet.write_cell_value(result || 0)
+        worksheet.writer.tag_elements('c', attributes) do
+          worksheet.write_cell_formula(token)
+          worksheet.write_cell_value(result || 0)
         end
       end
     end
 
     class FormulaArrayCellData < CellData # :nodoc:
-      def initialize(worksheet, row, col, formula, xf, range, result)
-        @worksheet = worksheet
-        @row = row
-        @col = col
+      attr_reader :token, :result, :range, :link_type, :url
+      def initialize(formula, xf, range, result)
         @token = formula
         @xf = xf
         @range = range
@@ -135,19 +128,17 @@ module Writexlsx
         @result || 0
       end
 
-      def write_cell
-        @worksheet.writer.tag_elements('c', cell_attributes) do
-          @worksheet.write_cell_array_formula(token, range)
-          @worksheet.write_cell_value(result)
+      def write_cell(worksheet, row, col)
+        worksheet.writer.tag_elements('c', cell_attributes(worksheet, row, col)) do
+          worksheet.write_cell_array_formula(token, range)
+          worksheet.write_cell_value(result)
         end
       end
     end
 
     class DynamicFormulaArrayCellData < CellData # :nodoc:
-      def initialize(worksheet, row, col, formula, xf, range, result)
-        @worksheet = worksheet
-        @row = row
-        @col = col
+      attr_reader :token, :result, :range, :link_type, :url
+      def initialize(formula, xf, range, result)
         @token = formula
         @xf = xf
         @range = range
@@ -158,23 +149,22 @@ module Writexlsx
         @result || 0
       end
 
-      def write_cell
+      def write_cell(worksheet, row, col)
         # Add metadata linkage for dynamic array formulas.
-        attributes = cell_attributes
+        attributes = cell_attributes(worksheet, row, col)
         attributes << %w[cm 1]
 
-        @worksheet.writer.tag_elements('c', attributes) do
-          @worksheet.write_cell_array_formula(token, range)
-          @worksheet.write_cell_value(result)
+        worksheet.writer.tag_elements('c', attributes) do
+          worksheet.write_cell_array_formula(token, range)
+          worksheet.write_cell_value(result)
         end
       end
     end
 
     class BooleanCellData < CellData # :nodoc:
-      def initialize(worksheet, row, col, val, xf)
-        @worksheet = worksheet
-        @row = row
-        @col = col
+      attr_reader :token
+
+      def initialize(val, xf)
         @token = val
         @xf = xf
       end
@@ -183,21 +173,18 @@ module Writexlsx
         @token
       end
 
-      def write_cell
-        attributes = cell_attributes
+      def write_cell(worksheet, row, col)
+        attributes = cell_attributes(worksheet, row, col)
 
         attributes << %w[t b]
-        @worksheet.writer.tag_elements('c', attributes) do
-          @worksheet.write_cell_value(token)
+        worksheet.writer.tag_elements('c', attributes) do
+          worksheet.write_cell_value(token)
         end
       end
     end
 
     class BlankCellData < CellData # :nodoc:
-      def initialize(worksheet, row, col, xf)
-        @worksheet = worksheet
-        @row = row
-        @col = col
+      def initialize(xf)
         @xf = xf
       end
 
@@ -205,8 +192,8 @@ module Writexlsx
         ''
       end
 
-      def write_cell
-        @worksheet.writer.empty_tag('c', cell_attributes)
+      def write_cell(worksheet, row, col)
+        worksheet.writer.empty_tag('c', cell_attributes(worksheet, row, col))
       end
     end
   end

--- a/test/worksheet/test_write_cell.rb
+++ b/test/worksheet/test_write_cell.rb
@@ -11,8 +11,8 @@ class TestWriteCell < Minitest::Test
   end
 
   def test_write_cell_0_0_n_1
-    cell_data = Writexlsx::Worksheet::NumberCellData.new(@worksheet, 0, 0, 1, nil)
-    cell_data.write_cell
+    cell_data = Writexlsx::Worksheet::NumberCellData.new(1, nil)
+    cell_data.write_cell(@worksheet, 0, 0)
     result = @worksheet.instance_variable_get(:@writer).string
     expected = '<c r="A1"><v>1</v></c>'
 
@@ -20,8 +20,8 @@ class TestWriteCell < Minitest::Test
   end
 
   def test_write_cell_3_1_s_0
-    cell_data = Writexlsx::Worksheet::StringCellData.new(@worksheet, 3, 1, 0, nil)
-    cell_data.write_cell
+    cell_data = Writexlsx::Worksheet::StringCellData.new(0, nil)
+    cell_data.write_cell(@worksheet, 3, 1)
     result = @worksheet.instance_variable_get(:@writer).string
     expected = '<c r="B4" t="s"><v>0</v></c>'
 
@@ -30,8 +30,8 @@ class TestWriteCell < Minitest::Test
 
   def test_write_cell_1_2_f_formula_nil_0
     format = nil
-    cell_data = Writexlsx::Worksheet::FormulaCellData.new(@worksheet, 1, 2, 'A3+A5', format, 0)
-    cell_data.write_cell
+    cell_data = Writexlsx::Worksheet::FormulaCellData.new('A3+A5', format, 0)
+    cell_data.write_cell(@worksheet, 1, 2)
     result = @worksheet.instance_variable_get(:@writer).string
     expected = '<c r="C2"><f>A3+A5</f><v>0</v></c>'
 
@@ -40,8 +40,8 @@ class TestWriteCell < Minitest::Test
 
   def test_write_cell_1_2_f_formula
     format = nil
-    cell_data = Writexlsx::Worksheet::FormulaCellData.new(@worksheet, 1, 2, 'A3+A5', nil, nil)
-    cell_data.write_cell
+    cell_data = Writexlsx::Worksheet::FormulaCellData.new('A3+A5', nil, nil)
+    cell_data.write_cell(@worksheet, 1, 2)
     result = @worksheet.instance_variable_get(:@writer).string
     expected = '<c r="C2"><f>A3+A5</f><v>0</v></c>'
 
@@ -50,8 +50,8 @@ class TestWriteCell < Minitest::Test
 
   def test_write_cell_0_0_a_formula_nil_a1_9500
     format = nil
-    cell_data = Writexlsx::Worksheet::FormulaArrayCellData.new(@worksheet, 0, 0, 'SUM(B1:C1*B2:C2)', format, 'A1', 9500)
-    cell_data.write_cell
+    cell_data = Writexlsx::Worksheet::FormulaArrayCellData.new('SUM(B1:C1*B2:C2)', format, 'A1', 9500)
+    cell_data.write_cell(@worksheet, 0, 0)
     result = @worksheet.instance_variable_get(:@writer).string
     expected = '<c r="A1"><f t="array" ref="A1">SUM(B1:C1*B2:C2)</f><v>9500</v></c>'
 


### PR DESCRIPTION
I remove storing of @worksheet, @col and @row in CellData object. This save about 10% RAM (CellData use up to 2 times less memory).
Also it reduce memory allocation count (system time) and overall execution time.

Used benchmark file is
```ruby
# -*- coding: utf-8 -*-

require 'helper'
require 'write_xlsx'
require 'stringio'
require "benchmark"
require 'memory_profiler'

class TestWritePane < Minitest::Test
  def setup
    @workbook = WriteXLSX.new(StringIO.new)
    @worksheet = @workbook.add_worksheet('')
    @data = (1..2000).map do |row|
      (1..50).map do |col|
        "R#{row}"
      end
    end
  end

  def test_add_table_memory_usage
    MemoryProfiler.start
    @worksheet.add_table 1, 1, @data.count, @data[1].count, data: @data
    report = MemoryProfiler.stop
    report.pretty_print(detailed_report: true)
  end

  def test_add_table_benchmark
    Benchmark.bm  do |x|
      x.report "Fill Table" do
        @worksheet.add_table 1, 1, @data.count, @data[1].count, data: @data
        @workbook.close
      end
    end
  end
end
```

Test result (partial) for Github version (main):
```
$ ruby -I test test/benchmark/test_write_benchmark.rb
Run options: --seed 20388

# Running:

       user     system      total        real
Fill Table  0.963618   0.008990   0.972608 (  0.975662)
.Total allocated: 34093616 bytes (506284 objects)
Total retained:  11615992 bytes (104310 objects)

allocated memory by gem
-----------------------------------
  34093368  write_xlsx/lib
       248  other

allocated memory by file
-----------------------------------
  18716776  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/worksheet.rb
   7998712  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/utility.rb
   7295800  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/package/table.rb
     81960  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/package/shared_strings.rb
       248  test/benchmark/test_write_benchmark.rb
       120  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/package/xml_writer_simple.rb

allocated memory by location
-----------------------------------
   8000000  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/worksheet.rb:1019
   7998040  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/utility.rb:256
   7196400  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/package/table.rb:150
   7196400  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/worksheet.rb:917
   3520000  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/worksheet.rb:3993
     81960  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/package/shared_strings.rb:30
     79960  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/package/table.rb:148
 ... 
```

After change:
```
$ ruby -I test test/benchmark/test_write_benchmark.rb
Run options: --seed 52348

# Running:

       user     system      total        real
Fill Table  0.924969   0.010954   0.935923 (  0.939881)
.Total allocated: 30093616 bytes (506284 objects)
Total retained:  7615992 bytes (104310 objects)

allocated memory by gem
-----------------------------------
  30093368  write_xlsx/lib
       248  other

allocated memory by file
-----------------------------------
  14716776  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/worksheet.rb
   7998712  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/utility.rb
   7295800  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/package/table.rb
     81960  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/package/shared_strings.rb
       248  test/benchmark/test_write_benchmark.rb
       120  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/package/xml_writer_simple.rb

allocated memory by location
-----------------------------------
   7998040  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/utility.rb:256
   7196400  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/package/table.rb:150
   7196400  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/worksheet.rb:917
   4000000  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/worksheet.rb:1019
   3520000  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/worksheet.rb:3992
     81960  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/package/shared_strings.rb:30
     79960  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/package/table.rb:148
 ... 
```

This patch can be combined with #96, the effect is cumulative:
```
# with #96 
# Running:

       user     system      total        real
Fill Table  0.939691   0.010922   0.950613 (  0.956120)
.Total allocated: 27485616 bytes (506284 objects)
Total retained:  5007992 bytes (104310 objects)

allocated memory by gem
-----------------------------------
  27485368  write_xlsx/lib
       248  other
...
```
