### PR TITLE
Update .gemspec required ruby version

### DIFF
--- a/write_xlsx.gemspec
+++ b/write_xlsx.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.summary       = 'write_xlsx is a gem to create a new file in the Excel 2007+ XLSX format.'
   gem.homepage      = 'https://github.com/cxn03651/write_xlsx#readme'
   gem.license       = 'MIT'
-  gem.required_ruby_version = '>= 2.5.0'
+  gem.required_ruby_version = '>= 2.6.0'
 
   gem.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
```
params = [range] + args[1..]
```

the syntax `[1..]` was introduced in ruby version 2.6.0.  Ruby versions below that are not compatible with the latest release of this gem.
https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/

> An endless range, (1..), works as if it has no end. Here are some typical use cases: