### PR TITLE
Removed redundant memory allocations, small performance optimizations

### DIFF
--- a/lib/write_xlsx/utility.rb
+++ b/lib/write_xlsx/utility.rb
@@ -53,7 +53,12 @@ module Writexlsx
 
     def xl_col_to_name(col, col_absolute)
       col_str = ColName.instance.col_str(col)
-      "#{absolute_char(col_absolute)}#{col_str}"
+      if col_absolute
+        "#{absolute_char(col_absolute)}#{col_str}"
+      else
+        # Do not allocate new string
+        col_str
+      end
     end
 
     def xl_range(row_1, row_2, col_1, col_2,
@@ -253,7 +258,7 @@ module Writexlsx
 
     # Check for a cell reference in A1 notation and substitute row and column
     def row_col_notation(args)   # :nodoc:
-      if args[0].to_s =~ /^\D/
+      if args[0].respond_to?(:match) && args[0] =~ /^\D/
         substitute_cellref(*args)
       else
         args

--- a/lib/write_xlsx/worksheet.rb
+++ b/lib/write_xlsx/worksheet.rb
@@ -2228,10 +2228,14 @@ module Writexlsx
     # Write the cell value <v> element.
     #
     def write_cell_value(value = '') # :nodoc:
-      return write_cell_formula('=NA()') if !value.nil? && value.is_a?(Float) && value.nan?
+      return write_cell_formula('=NA()') if value.is_a?(Float) && value.nan?
 
       value ||= ''
-      value = value.to_i if value == value.to_i
+
+      int_value = value.to_i
+      if value == int_value
+        value = int_value
+      end
       @writer.data_element('v', value)
     end
 
@@ -3333,8 +3337,11 @@ EOS
     end
 
     def write_cell_column_dimension(row_num)  # :nodoc:
+      row = @cell_data_table[row_num]
       (@dim_colmin..@dim_colmax).each do |col_num|
-        @cell_data_table[row_num][col_num].write_cell(self, row_num, col_num) if @cell_data_table[row_num][col_num]
+        if (cell = row[col_num])
+          cell.write_cell(self, row_num, col_num)
+        end
       end
     end
 


### PR DESCRIPTION
I check with memory_profiler, RAM usage reduced ~30% on `worksheet#add_table`.

Before is:
```shell
Total allocated: 29021040 bytes (504633 objects)
Total retained:  4923928 bytes (102166 objects)

allocated memory by gem
-----------------------------------
  29020752  write_xlsx/lib
       248  other
        40  singleton
...
```

After change is:
```shell
Total allocated: 21022840 bytes (304678 objects)
Total retained:  4923928 bytes (102166 objects)

allocated memory by gem
-----------------------------------
  21022552  write_xlsx/lib
       248  other
        40  singleton
...
```

Test script is:
```Ruby
# -*- coding: utf-8 -*-

require 'helper'
require 'write_xlsx'
require 'stringio'
require "benchmark"
require 'memory_profiler' # required gem memory_profiler in gemspec

class TestWriteBenchmark < Minitest::Test
  def setup
    @workbook = WriteXLSX.new(StringIO.new)
    @worksheet = @workbook.add_worksheet('')
    col_count = 50
    @data = (1..2000).map do |row|
      (1..col_count).map do |col|
        -"R#{row}"
      end
    end.freeze
    @format = @workbook.add_format(font: 'Calibri', size: 10, align: 'left', num_format: 49, border: 1)
    @formats = [@format] * col_count
  end

  def test_add_table_memory_usage
    # return
    MemoryProfiler.start
    @worksheet.add_table 1, 1, @data.count, @data[1].count, data: @data, columns: @formats
    report = MemoryProfiler.stop
    report.pretty_print(detailed_report: true)
    @workbook.close
  end

end

```
