### PR TITLE
Removed (partial) using of splat(*) operator for Worksheet#write.

### DIFF
--- a/lib/write_xlsx/package/table.rb
+++ b/lib/write_xlsx/package/table.rb
@@ -148,7 +148,7 @@ module Writexlsx
           j = 0    # For indexing the col data.
           (@col1..@col2).each do |col|
             token = data[i][j]
-            @worksheet.write(row, col, token, @col_formats[j]) if token
+            @worksheet.write_item(row, col, token, @col_formats[j]) if token
             j += 1
           end
           i += 1


### PR DESCRIPTION
@cxn03651  please consider this patch.
I discover that splat call `Worksheet#write(*args)` allocate additional array every time.
I append additional methods without splats (old signatures still works) and switch internal calls to it.
RAM usage reduced up to 6 times. Now `Worksheet#add_table` allocate only single object for each simple cell.

Profile before:
```shell
Total allocated: 29021040 bytes (504633 objects)
Total retained:  4923928 bytes (102166 objects)

allocated memory by gem
-----------------------------------
  29020752  write_xlsx/lib
       248  other
        40  singleton
...
```

Profile after:
```shell
Total allocated: 5033040 bytes (104833 objects)
Total retained:  4923928 bytes (102166 objects)

allocated memory by gem
-----------------------------------
   5032752  write_xlsx/lib
       248  other
        40  singleton
...
```

Test script is:
```ruby
# -*- coding: utf-8 -*-

require 'helper'
require 'write_xlsx'
require 'stringio'
require "benchmark"
require 'memory_profiler' # required gem memory_profiler in gemspec
# require 'ruby-prof'

class TestWriteBenchmark < Minitest::Test
  def setup
    @workbook = WriteXLSX.new(StringIO.new)
    @worksheet = @workbook.add_worksheet('')
    col_count = 50
    @data = (1..2000).map do |row|
      (1..col_count).map do |col|
        -"R#{row}"
        # "a"
      end
    end.freeze
    @format = @workbook.add_format(font: 'Calibri', size: 10, align: 'left', num_format: 49, border: 1)
    @formats = [@format] * col_count
  end

  def test_add_table_memory_usage
    # return
    MemoryProfiler.start
    @worksheet.add_table 1, 1, @data.count, @data[1].count, data: @data, columns: @formats
    report = MemoryProfiler.stop
    report.pretty_print(detailed_report: true)
    @workbook.close
  end
end

```
