### PR TITLE
Exclude integer#to_s conversation for integer row_col

### DIFF
--- a/lib/write_xlsx/utility.rb
+++ b/lib/write_xlsx/utility.rb
@@ -258,7 +258,7 @@ module Writexlsx
 
     # Check for a cell reference in A1 notation and substitute row and column
     def row_col_notation(row_or_a1)   # :nodoc:
-      substitute_cellref(row_or_a1) if row_or_a1.to_s =~ /^\D/
+      substitute_cellref(row_or_a1) if row_or_a1.respond_to?(:match) && row_or_a1.to_s =~ /^\D/
     end
 
     #


### PR DESCRIPTION
This conversation did twice for cell append.

Memory allocations before:

```shell
Total allocated: 13041680 bytes (305083 objects)
Total retained:  4924608 bytes (102162 objects)

allocated memory by gem
-----------------------------------
  13041432  write_xlsx/lib
       248  other

allocated memory by file
-----------------------------------
   7998560  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/utility.rb
   4912376  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/worksheet.rb
     98136  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/package/table.rb
     32000  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/format.rb
```

After:

```shell
Total allocated: 5043640 bytes (105132 objects)
Total retained:  4924608 bytes (102162 objects)

allocated memory by gem
-----------------------------------
   5043392  write_xlsx/lib
       248  other

allocated memory by file
-----------------------------------
   4912376  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/worksheet.rb
     98136  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/package/table.rb
     32000  /home/ukolovda/RubymineProjects/external/write_xlsx/lib/write_xlsx/format.rb
```
