### PR TITLE
Small RAM allocations reduce when save worksheet

### DIFF
--- a/lib/write_xlsx/col_name.rb
+++ b/lib/write_xlsx/col_name.rb
@@ -7,12 +7,16 @@ class ColName
   include Singleton
 
   def initialize
-    @col_str_table = {}
+    @col_str_table = []
+    @row_str_table = []
   end
 
   def col_str(col)
-    @col_str_table[col] = col_str_build(col) unless @col_str_table[col]
-    @col_str_table[col]
+    @col_str_table[col] ||= col_str_build(col)
+  end
+
+  def row_str(row)
+    @row_str_table[row] ||= row.to_s
   end
 
   private

--- a/lib/write_xlsx/utility.rb
+++ b/lib/write_xlsx/utility.rb
@@ -34,7 +34,8 @@ module Writexlsx
     def xl_rowcol_to_cell(row, col, row_absolute = false, col_absolute = false)
       row += 1      # Change from 0-indexed to 1 indexed.
       col_str = xl_col_to_name(col, col_absolute)
-      "#{col_str}#{absolute_char(row_absolute)}#{row}"
+      row_str = ColName.instance.row_str(row)
+      "#{col_str}#{absolute_char(row_absolute)}#{row_str}"
     end
 
     #


### PR DESCRIPTION
I append cache for row number to string conversation. It reduce RAM usage about  ~7% (table have 2000 rows by 50 columns). Also change storage from Hash to Array (it is very small optimization).

Ruby 3.2.2

```ruby
# ram_usage_test.rb
require 'memory_profiler' # required gem memory_profiler in Gemfile

def test_save_table_memory_usage
    @workbook = WriteXLSX.new(StringIO.new)
    @worksheet = @workbook.add_worksheet('')
    col_count = 50
    @data = (1..2000).map do |row|
      (1..col_count).map do |col|
        -"R#{row}"
        # "a"
        # row
      end
    end.freeze
    @format = @workbook.add_format(font: 'Calibri', size: 10, align: 'left', num_format: 49, border: 1)
    @formats = [@format] * col_count

    @worksheet.add_table 1, 1, @data.count, @data[1].count, data: @data, columns: @formats

    MemoryProfiler.start
    @workbook.close
    report = MemoryProfiler.stop
    report.pretty_print(detailed_report: true)
end
```

RAM statistics before:
```
Total allocated: 75107352 bytes (1446526 objects)
Total retained:  9203928 bytes (102399 objects)

allocated memory by gem
-----------------------------------
  69554610  write_xlsx/lib
   5527315  rubyzip-2.3.2
     12005  fileutils
     11022  other
      1800  delegate
       600  tmpdir
...
```

RAM statistics after:
```
Total allocated: 71191912 bytes (1348640 objects)
Total retained:  9273168 bytes (104130 objects)

allocated memory by gem
-----------------------------------
  65639170  write_xlsx/lib
   5527315  rubyzip-2.3.2
     12005  fileutils
     11022  other
      1800  delegate
       600  tmpdir
...
```
