### PR TITLE
Reduced RAM usage when generate row name for data writing

### DIFF
--- a/lib/write_xlsx/utility.rb
+++ b/lib/write_xlsx/utility.rb
@@ -31,10 +31,12 @@ module Writexlsx
     #
     # xl_rowcol_to_cell($row, col, row_absolute, col_absolute)
     #
-    def xl_rowcol_to_cell(row, col, row_absolute = false, col_absolute = false)
-      row += 1      # Change from 0-indexed to 1 indexed.
+    def xl_rowcol_to_cell(row_or_name, col, row_absolute = false, col_absolute = false)
+      if row_or_name.is_a?(Integer)
+        row_or_name += 1      # Change from 0-indexed to 1 indexed.
+      end
       col_str = xl_col_to_name(col, col_absolute)
-      "#{col_str}#{absolute_char(row_absolute)}#{row}"
+      "#{col_str}#{absolute_char(row_absolute)}#{row_or_name}"
     end
 
     #

--- a/lib/write_xlsx/worksheet.rb
+++ b/lib/write_xlsx/worksheet.rb
@@ -3785,9 +3785,10 @@ EOS
 
     def write_cell_column_dimension(row_num)  # :nodoc:
       row = @cell_data_table[row_num]
+      row_name = (row_num+1).to_s
       (@dim_colmin..@dim_colmax).each do |col_num|
         if (cell = row[col_num])
-          cell.write_cell(self, row_num, col_num)
+          cell.write_cell(self, row_num, row_name, col_num)
         end
       end
     end

--- a/lib/write_xlsx/worksheet/cell_data.rb
+++ b/lib/write_xlsx/worksheet/cell_data.rb
@@ -12,10 +12,10 @@ module Writexlsx
       # attributes for the <cell> element. This is the innermost loop so efficiency is
       # important where possible.
       #
-      def cell_attributes(worksheet, row, col) # :nodoc:
+      def cell_attributes(worksheet, row, row_name, col) # :nodoc:
         xf_index = xf ? xf.get_xf_index : 0
         attributes = [
-          ['r', xl_rowcol_to_cell(row, col)]
+          ['r', xl_rowcol_to_cell(row_name, col)]
         ]
 
         # Add the cell format index.
@@ -48,8 +48,8 @@ module Writexlsx
         @token
       end
 
-      def write_cell(worksheet, row, col)
-        worksheet.writer.tag_elements('c', cell_attributes(worksheet, row, col)) do
+      def write_cell(worksheet, row, row_name, col)
+        worksheet.writer.tag_elements('c', cell_attributes(worksheet, row, row_name, col)) do
           worksheet.write_cell_value(token)
         end
       end
@@ -69,8 +69,8 @@ module Writexlsx
       end
 
       TYPE_STR_ATTRS = %w[t s].freeze
-      def write_cell(worksheet, row, col)
-        attributes = cell_attributes(worksheet, row, col)
+      def write_cell(worksheet, row, row_name, col)
+        attributes = cell_attributes(worksheet, row, row_name, col)
         attributes << TYPE_STR_ATTRS
         worksheet.writer.tag_elements('c', attributes) do
           worksheet.write_cell_value(token)
@@ -101,11 +101,11 @@ module Writexlsx
         @result || 0
       end
 
-      def write_cell(worksheet, row, col)
+      def write_cell(worksheet, row, row_name, col)
         truefalse = { 'TRUE' => 1, 'FALSE' => 0 }
         error_code = ['#DIV/0!', '#N/A', '#NAME?', '#NULL!', '#NUM!', '#REF!', '#VALUE!']
 
-        attributes = cell_attributes(worksheet, row, col)
+        attributes = cell_attributes(worksheet, row, row_name, col)
         if @result && !(@result.to_s =~ /^([+-]?)(?=\d|\.\d)\d*(\.\d*)?([Ee]([+-]?\d+))?$/)
           if truefalse[@result]
             attributes << %w[t b]
@@ -137,8 +137,8 @@ module Writexlsx
         @result || 0
       end
 
-      def write_cell(worksheet, row, col)
-        worksheet.writer.tag_elements('c', cell_attributes(worksheet, row, col)) do
+      def write_cell(worksheet, row, row_name, col)
+        worksheet.writer.tag_elements('c', cell_attributes(worksheet, row, row_name, col)) do
           worksheet.write_cell_array_formula(token, range)
           worksheet.write_cell_value(result)
         end
@@ -159,9 +159,9 @@ module Writexlsx
         @result || 0
       end
 
-      def write_cell(worksheet, row, col)
+      def write_cell(worksheet, row, row_name, col)
         # Add metadata linkage for dynamic array formulas.
-        attributes = cell_attributes(worksheet, row, col)
+        attributes = cell_attributes(worksheet, row, row_name, col)
         attributes << %w[cm 1]
 
         worksheet.writer.tag_elements('c', attributes) do
@@ -183,8 +183,8 @@ module Writexlsx
         @token
       end
 
-      def write_cell(worksheet, row, col)
-        attributes = cell_attributes(worksheet, row, col)
+      def write_cell(worksheet, row, row_name, col)
+        attributes = cell_attributes(worksheet, row, row_name, col)
 
         attributes << %w[t b]
         worksheet.writer.tag_elements('c', attributes) do
@@ -202,8 +202,8 @@ module Writexlsx
         ''
       end
 
-      def write_cell(worksheet, row, col)
-        worksheet.writer.empty_tag('c', cell_attributes(worksheet, row, col))
+      def write_cell(worksheet, row, row_name, col)
+        worksheet.writer.empty_tag('c', cell_attributes(worksheet, row, row_name, col))
       end
     end
   end


### PR DESCRIPTION
RAM usage reduced from 70 to 66 Mb in my example (table with 50 columns and 2000 rows).

MemoryProfiler statistics before:

```
Total allocated: 70070873 bytes (1341650 objects)
Total retained:  4274328 bytes (189 objects)

allocated memory by gem
-----------------------------------
  64518379  write_xlsx/lib
   5527315  rubyzip-2.3.2
     12005  fileutils
     10774  other
      1800  delegate
       600  tmpdir
```


MemoryProfiler statistics after:

```
Total allocated: 66166872 bytes (1244050 objects)
Total retained:  4274328 bytes (189 objects)

allocated memory by gem
-----------------------------------
  60614378  write_xlsx/lib
   5527315  rubyzip-2.3.2
     12005  fileutils
     10774  other
      1800  delegate
       600  tmpdir
```

Execution time did not changed (check rake test).