### PR TITLE
Good RAM optimization, up to 30% less on table writing

### DIFF
--- a/lib/write_xlsx/package/xml_writer_simple.rb
+++ b/lib/write_xlsx/package/xml_writer_simple.rb
@@ -126,17 +126,23 @@ module Writexlsx
 
       private
 
-      def key_val(key, val)
-        %( #{key}="#{val}")
-      end
-
       def key_vals(attribute)
-        attribute
-          &.inject('') { |str, attr| str + key_val(attr.first, escape_attributes(attr.last)) }
+        if attribute
+          result = "".dup
+          attribute.each do |attr|
+            # Generate and concat %( #{key}="#{val}") values for attribute pair
+            result << " "
+            result << attr.first.to_s
+            result << '="'
+            result << escape_attributes(attr.last).to_s
+            result << '"'
+          end
+          result
+        end
       end
 
       def escape_attributes(str = '')
-        return str unless str.to_s =~ /["&<>\n]/
+        return str unless str.respond_to?(:match) && str =~ /["&<>\n]/
 
         str
           .gsub("&", "&amp;")
@@ -147,7 +153,7 @@ module Writexlsx
       end
 
       def escape_data(str = '')
-        if str.to_s =~ /[&<>]/
+        if str.respond_to?(:match) && str =~ /[&<>]/
           str.gsub("&", '&amp;')
              .gsub("<", '&lt;')
              .gsub(">", '&gt;')


### PR DESCRIPTION
MemoryProfiler statistics before: 
```
Total allocated: 62083791 bytes (1141973 objects)
Total retained:  4274328 bytes (189 objects)

allocated memory by gem
-----------------------------------
  56531297  write_xlsx/lib
   5527315  rubyzip-2.3.2
     12005  fileutils
     10774  other
      1800  delegate
       600  tmpdir
```


MemoryProfiler statistics after:
```
Total allocated: 45139199 bytes (733561 objects)
Total retained:  4274328 bytes (189 objects)

allocated memory by gem
-----------------------------------
  39586705  write_xlsx/lib
   5527315  rubyzip-2.3.2
     12005  fileutils
     10774  other
      1800  delegate
       600  tmpdir
```
 
Rewrote XMLWriterSimple#key_vals as simple loop and storing result to single string (it does not memory allocation for short strings). Also have little performance win (`rake test` executed for 9,2 second vs 9,4 for old code).