### PR TITLE
zip_file_utils: Update Zip::File.open() args

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Change history of write_xlsx rubygem.
 
+2025-07-29
+    Bump rubyzip version to 3.x.
+
 2024-04-12 v1.12.1
     Added support for embedding images into worksheets with
     worksheet `embed_image()`.

--- a/lib/write_xlsx/zip_file_utils.rb
+++ b/lib/write_xlsx/zip_file_utils.rb
@@ -16,7 +16,7 @@ module ZipFileUtils
     src = File.expand_path(src)
     dest = File.expand_path(dest)
     FileUtils.rm_f(dest)
-    Zip::File.open(dest, Zip::File::CREATE) do |zf|
+    Zip::File.open(dest, create: true) do |zf|
       if File.file?(src)
         zf.add(encode_path(File.basename(src), options[:fs_encoding]), src)
         break

--- a/write_xlsx.gemspec
+++ b/write_xlsx.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.require_paths = ['lib']
   gem.add_dependency 'nkf'
-  gem.add_dependency 'rubyzip', '>= 1.0.0'
+  gem.add_dependency 'rubyzip', '>= 3.0.0'
   gem.add_development_dependency 'byebug'
   gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'mutex_m'


### PR DESCRIPTION
Update call to `rubyzip` gem to support the newly-released major version.

### Test Plan
Existing unit tests.